### PR TITLE
Replace all newlines with spaces

### DIFF
--- a/src/main/java/com/namelessmc/bot/listeners/MessageReceivedOCR.java
+++ b/src/main/java/com/namelessmc/bot/listeners/MessageReceivedOCR.java
@@ -53,6 +53,7 @@ public class MessageReceivedOCR extends ListenerAdapter {
                         // Creating buffered image to do OCR on with tesseract
                         BufferedImage imgBuff = ImageIO.read(y);
                         String textOut = OCRProcessor.extractTextFromImage(imgBuff);
+                        textOut = textOut.replace("\n", " ");
 
                         JsonObject matchResponse = matchResponse(textOut);
                         if (matchResponse != null) {


### PR DESCRIPTION
Replace all newlines when running OCR with spaces to enhance the ability to run detections.