### PR TITLE
Allow autoresponses to define a `command` that should be run

### DIFF
--- a/src/events/MessageScanner.event.ts
+++ b/src/events/MessageScanner.event.ts
@@ -73,10 +73,14 @@ export default class ReadyEvent extends Event<"messageCreate"> {
         const debugLinkCheckResult = await runDebugChecks(text);
 
         if (textCheckResult) {
-            const sent = await msg.channel.send({
-                embeds: [client.embeds.MakeResponse(textCheckResult)],
-            });
-            await sent.react("🗑️");
+            if (textCheckResult.command !== undefined) {
+                await msg.channel.send(textCheckResult.command);
+            } else {
+                const sent = await msg.channel.send({
+                    embeds: [client.embeds.MakeResponse(textCheckResult.response)],
+                });
+                await sent.react("🗑️");
+            }
         }
         if (debugLinkCheckResult) {
             const sent = await msg.channel.send({
@@ -99,7 +103,7 @@ const runTextChecks = async (text: string) => {
             continue;
         }
 
-        return response.response;
+        return response;
     }
 };
 


### PR DESCRIPTION
When making this autoresponse,
https://github.com/NamelessMC/BotConfiguration/blob/master/autoresponse.js#L278
I realized it would be nice if we could just tell the bot which command to run instead of duplicating the text.

For example:
```json
    {
        "keywords": [["badge", "colors"], ["badge", "colours"], ["badge", "color"], ["badge", "colour"], ["group html", "colors"], ["group html", "colours"], ["group html", "color"], ["group html", "colour"]],
        "command": "/support v2/group-html"
    }
```
instead of copy/pasting the huge block of text.

I have not tested this :shipit: 