### PR TITLE
Fixed Logger Incorrect Sizing

### DIFF
--- a/src/handlers/Logger.ts
+++ b/src/handlers/Logger.ts
@@ -6,13 +6,8 @@ export default class Logger {
     //
 
     public static makeSize(string: string, length: number): string {
-        if (string.length >= length) return string.slice(0, 5);
-
-        while (string.length < length) {
-            string += " ";
-        }
-
-        return string;
+        if (string.length >= length) return string.slice(0, length);
+        return string + " ".repeat(length - string.length);
     }
 
     public static getLineAndChar(


### PR DESCRIPTION
The **[`makeSize`](https://github.com/NamelessMC/NamelessBot/blob/06a74b7de5e6040792b4d74782df439c3bdab8c9/src/handlers/Logger.ts#L8)** method in **`Logger.ts`** would not slice the string to intended size **if its length was greater than limit**, instead it always extracts the first 5 characters.

This pull request **fixes the issue**, and **enhances readability** of the line afterwards by replacing **`while loop`** with **`.repeat()`**.