### PR TITLE
Replace Native Console Log with Custom Logger

### DIFF
--- a/src/events/guildMemberAdd.event.ts
+++ b/src/events/guildMemberAdd.event.ts
@@ -31,9 +31,7 @@ export default class InteractionCreate extends Event<"guildMemberAdd"> {
         await channel
             .send({ embeds: [embed] })
             .catch((ignored) =>
-                console.log(
-                    "Something went wrong while sending the welcome message"
-                )
+                this.client.logger.error("Something went wrong while sending the welcome message")
             );
     }
 }

--- a/src/events/guildMemberRemove.event.ts
+++ b/src/events/guildMemberRemove.event.ts
@@ -33,9 +33,7 @@ export default class InteractionCreate extends Event<"guildMemberRemove"> {
         await channel
             .send({ embeds: [embed] })
             .catch((ignored) =>
-                console.log(
-                    "Something went wrong while sending the welcome message"
-                )
+                this.client.logger.error("Something went wrong while sending the leave message")
             );
     }
 }


### PR DESCRIPTION
In files **[`guildMemberAdd.event.ts`](https://github.com/NamelessMC/NamelessBot/blob/4b1ce815898a51b299bb401d96cc461a3b4dd24b/src/events/guildMemberAdd.event.ts#L34)** and **[`guildMemberRemove.event.ts`](https://github.com/NamelessMC/NamelessBot/blob/4b1ce815898a51b299bb401d96cc461a3b4dd24b/src/events/guildMemberRemove.event.ts#L36)**, native **`console.log`** was used instead of **`Logger.error()`**.

The issue isn't critical, but it would be great to **standardize** the use of logging methods.